### PR TITLE
LiveData & Obervers

### DIFF
--- a/app/src/main/java/com/rootstrap/android/ui/activity/main/ProfileActivity.kt
+++ b/app/src/main/java/com/rootstrap/android/ui/activity/main/ProfileActivity.kt
@@ -1,6 +1,7 @@
 package com.rootstrap.android.ui.activity.main
 
 import android.os.Bundle
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.rootstrap.android.R
 import com.rootstrap.android.metrics.Analytics
@@ -10,7 +11,6 @@ import com.rootstrap.android.network.managers.SessionManager
 import com.rootstrap.android.ui.base.BaseActivity
 import com.rootstrap.android.ui.view.ProfileView
 import com.rootstrap.android.util.NetworkState
-import com.rootstrap.android.util.ViewModelListener
 import kotlinx.android.synthetic.main.activity_profile.*
 
 class ProfileActivity : BaseActivity(), ProfileView {
@@ -21,8 +21,7 @@ class ProfileActivity : BaseActivity(), ProfileView {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_profile)
 
-        val factory = ProfileActivityViewModelFactory(viewModelListener)
-        viewModel = ViewModelProvider(this, factory)
+        viewModel = ViewModelProvider(this)
             .get(ProfileActivityViewModel::class.java)
 
         Analytics.track(PageEvents.visit(VISIT_PROFILE))
@@ -31,29 +30,27 @@ class ProfileActivity : BaseActivity(), ProfileView {
         sign_out_button.setOnClickListener { viewModel.signOut() }
 
         lifecycle.addObserver(viewModel)
+        setObservers()
     }
 
     override fun goToFirstScreen() {
         startActivityClearTask(SignUpActivity())
     }
 
-    // ViewModelListener
-    private val viewModelListener = object : ViewModelListener {
-        override fun updateState() {
-            when (viewModel.state) {
+    private fun setObservers() {
+        viewModel.state.observe(this, Observer {
+            when (it) {
                 ProfileState.signOutFailure -> showError(viewModel.error)
                 ProfileState.signOutSuccess -> goToFirstScreen()
-                else -> {
-                }
             }
-        }
+        })
 
-        override fun updateNetworkState() {
-            when (viewModel.networkState) {
+        viewModel.networkState.observe(this, Observer {
+            when (it) {
                 NetworkState.loading -> showProgress()
                 NetworkState.idle -> hideProgress()
                 else -> showError(viewModel.error ?: getString(R.string.default_error))
             }
-        }
+        })
     }
 }

--- a/app/src/main/java/com/rootstrap/android/ui/activity/main/SignInActivity.kt
+++ b/app/src/main/java/com/rootstrap/android/ui/activity/main/SignInActivity.kt
@@ -2,6 +2,7 @@ package com.rootstrap.android.ui.activity.main
 
 import android.Manifest
 import android.os.Bundle
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.rootstrap.android.R
 import com.rootstrap.android.databinding.ActivitySignInBinding
@@ -11,7 +12,6 @@ import com.rootstrap.android.metrics.VISIT_SIGN_IN
 import com.rootstrap.android.network.models.User
 import com.rootstrap.android.ui.view.AuthView
 import com.rootstrap.android.util.NetworkState
-import com.rootstrap.android.util.ViewModelListener
 import com.rootstrap.android.util.extensions.value
 import com.rootstrap.android.util.permissions.PermissionActivity
 import com.rootstrap.android.util.permissions.PermissionResponse
@@ -28,8 +28,7 @@ class SignInActivity : PermissionActivity(), AuthView {
         setContentView(R.layout.activity_sign_in)
         Analytics.track(PageEvents.visit(VISIT_SIGN_IN))
 
-        val factory = SignInActivityViewModelFactory(viewModelListener)
-        viewModel = ViewModelProvider(this, factory)
+        viewModel = ViewModelProvider(this)
             .get(SignInActivityViewModel::class.java)
 
         binding.signInButton.setOnClickListener { signIn() }
@@ -37,6 +36,7 @@ class SignInActivity : PermissionActivity(), AuthView {
         lifecycle.addObserver(viewModel)
 
         sampleAskForPermission()
+        setObservers()
     }
 
     override fun showProfile() {
@@ -53,24 +53,21 @@ class SignInActivity : PermissionActivity(), AuthView {
         }
     }
 
-    // ViewModelListener
-    private val viewModelListener = object : ViewModelListener {
-        override fun updateState() {
-            when (viewModel.state) {
+    private fun setObservers() {
+        viewModel.state.observe(this, Observer {
+            when (it) {
                 SignInState.signInFailure -> showError(viewModel.error)
                 SignInState.signInSuccess -> showProfile()
-                else -> {
-                }
             }
-        }
+        })
 
-        override fun updateNetworkState() {
-            when (viewModel.networkState) {
+        viewModel.networkState.observe(this, Observer {
+            when (it) {
                 NetworkState.loading -> showProgress()
                 NetworkState.idle -> hideProgress()
                 else -> showError(viewModel.error ?: getString(R.string.default_error))
             }
-        }
+        })
     }
 
     private fun sampleAskForPermission() {

--- a/app/src/main/java/com/rootstrap/android/ui/activity/main/SignInActivityViewModel.kt
+++ b/app/src/main/java/com/rootstrap/android/ui/activity/main/SignInActivityViewModel.kt
@@ -1,7 +1,7 @@
 package com.rootstrap.android.ui.activity.main
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.rootstrap.android.network.managers.IUserManager
 import com.rootstrap.android.network.managers.SessionManager
@@ -9,23 +9,20 @@ import com.rootstrap.android.network.managers.UserManager
 import com.rootstrap.android.network.models.User
 import com.rootstrap.android.ui.base.BaseViewModel
 import com.rootstrap.android.util.NetworkState
-import com.rootstrap.android.util.ViewModelListener
 import com.rootstrap.android.util.extensions.ApiErrorType
 import com.rootstrap.android.util.extensions.ApiException
 import kotlinx.coroutines.launch
 
-open class SignInActivityViewModel(listener: ViewModelListener?) : BaseViewModel(listener) {
+open class SignInActivityViewModel : BaseViewModel() {
 
     private val manager: IUserManager = UserManager
 
-    var state: SignInState = SignInState.none
-        set(value) {
-            field = value
-            listener?.updateState()
-        }
+    private val _state = MutableLiveData<SignInState>()
+    val state: LiveData<SignInState>
+        get() = _state
 
     fun signIn(user: User) {
-        networkState = NetworkState.loading
+        _networkState.value = NetworkState.loading
         viewModelScope.launch {
             val result = manager.signIn(user = user)
             if (result.isSuccess) {
@@ -33,8 +30,8 @@ open class SignInActivityViewModel(listener: ViewModelListener?) : BaseViewModel
                     SessionManager.signIn(user)
                 }
 
-                networkState = NetworkState.idle
-                state = SignInState.signInSuccess
+                _networkState.value = NetworkState.idle
+                _state.value = SignInState.signInSuccess
             } else {
                 handleError(result.exceptionOrNull())
             }
@@ -46,20 +43,13 @@ open class SignInActivityViewModel(listener: ViewModelListener?) : BaseViewModel
             exception.message
         } else null
 
-        networkState = NetworkState.idle
-        networkState = NetworkState.error
-        state = SignInState.signInFailure
+        _networkState.value = NetworkState.idle
+        _networkState.value = NetworkState.error
+        _state.value = SignInState.signInFailure
     }
 }
 
 enum class SignInState {
     signInFailure,
-    signInSuccess,
-    none,
-}
-
-class SignInActivityViewModelFactory(var listener: ViewModelListener?) : ViewModelProvider.Factory {
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        return SignInActivityViewModel(listener) as T
-    }
+    signInSuccess
 }

--- a/app/src/main/java/com/rootstrap/android/ui/activity/main/SignUpActivityViewModel.kt
+++ b/app/src/main/java/com/rootstrap/android/ui/activity/main/SignUpActivityViewModel.kt
@@ -1,7 +1,7 @@
 package com.rootstrap.android.ui.activity.main
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.rootstrap.android.network.managers.IUserManager
 import com.rootstrap.android.network.managers.SessionManager
@@ -9,23 +9,20 @@ import com.rootstrap.android.network.managers.UserManager
 import com.rootstrap.android.network.models.User
 import com.rootstrap.android.ui.base.BaseViewModel
 import com.rootstrap.android.util.NetworkState
-import com.rootstrap.android.util.ViewModelListener
 import com.rootstrap.android.util.extensions.ApiErrorType
 import com.rootstrap.android.util.extensions.ApiException
 import kotlinx.coroutines.launch
 
-open class SignUpActivityViewModel(listener: ViewModelListener?) : BaseViewModel(listener) {
+open class SignUpActivityViewModel : BaseViewModel() {
 
     private val manager: IUserManager = UserManager
 
-    var state: SignUpState = SignUpState.none
-        set(value) {
-            field = value
-            listener?.updateState()
-        }
+    private val _state = MutableLiveData<SignUpState>()
+    val state: LiveData<SignUpState>
+        get() = _state
 
     fun signUp(user: User) {
-        networkState = NetworkState.loading
+        _networkState.value = NetworkState.loading
         viewModelScope.launch {
             val result = manager.signUp(user = user)
 
@@ -34,8 +31,8 @@ open class SignUpActivityViewModel(listener: ViewModelListener?) : BaseViewModel
                     SessionManager.signIn(user)
                 }
 
-                networkState = NetworkState.idle
-                state = SignUpState.signUpSuccess
+                _networkState.value = NetworkState.idle
+                _state.value = SignUpState.signUpSuccess
             } else {
                 handleError(result.exceptionOrNull())
             }
@@ -47,20 +44,13 @@ open class SignUpActivityViewModel(listener: ViewModelListener?) : BaseViewModel
             exception.message
         } else null
 
-        networkState = NetworkState.idle
-        networkState = NetworkState.error
-        state = SignUpState.signUpFailure
+        _networkState.value = NetworkState.idle
+        _networkState.value = NetworkState.error
+        _state.value = SignUpState.signUpFailure
     }
 }
 
 enum class SignUpState {
     signUpFailure,
-    signUpSuccess,
-    none,
-}
-
-class SignUpActivityViewModelFactory(var listener: ViewModelListener?) : ViewModelProvider.Factory {
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        return SignUpActivityViewModel(listener) as T
-    }
+    signUpSuccess
 }

--- a/app/src/main/java/com/rootstrap/android/ui/base/BaseViewModel.kt
+++ b/app/src/main/java/com/rootstrap/android/ui/base/BaseViewModel.kt
@@ -2,24 +2,23 @@ package com.rootstrap.android.ui.base
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ViewModel
 import com.rootstrap.android.bus
 import com.rootstrap.android.util.NetworkState
-import com.rootstrap.android.util.ViewModelListener
 
 /**
  * A [ViewModel] base class
  * implement app general LiveData as Session or User
  * **/
-open class BaseViewModel(var listener: ViewModelListener?) : ViewModel(), LifecycleObserver {
+open class BaseViewModel : ViewModel(), LifecycleObserver {
     var error: String? = null
 
-    var networkState: NetworkState = NetworkState.idle
-        set(value) {
-            field = value
-            listener?.updateNetworkState()
-        }
+    protected val _networkState = MutableLiveData<NetworkState>()
+    val networkState: LiveData<NetworkState>
+        get() = _networkState
 
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     fun register() = bus.register(this)

--- a/app/src/main/java/com/rootstrap/android/util/NetworkState.kt
+++ b/app/src/main/java/com/rootstrap/android/util/NetworkState.kt
@@ -1,10 +1,5 @@
 package com.rootstrap.android.util
 
-interface ViewModelListener {
-    fun updateState()
-    fun updateNetworkState()
-}
-
 enum class NetworkState {
     loading,
     idle,


### PR DESCRIPTION
### Summary
- To avoid using interfaces in ViewModel's constructor to communicate changes to Fragment (View), they were replaced with LiveData and Observers.
- This avoids creating ViewModelsFactory classes and some other boilerplate.   